### PR TITLE
add standard kk meta & L3 themes

### DIFF
--- a/code_schemes/s01e01.json
+++ b/code_schemes/s01e01.json
@@ -14,6 +14,146 @@
         "Shortcut": "e"
       },
       {
+        "CodeID": "code-Q-a5d3700d",
+        "CodeType": "Meta",
+        "MetaCode": "question",
+        "DisplayText": "meta: question",
+        "NumericValue": -100010,
+        "StringValue": "question",
+        "VisibleInCoda": true,
+        "Shortcut": "q"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "CodeID": "code-ff8f597e",
+        "CodeType": "Normal",
+        "DisplayText": "about coronavirus",
+        "NumericValue": 1,
+        "StringValue": "about_coronavirus",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-fe7cb915",
+        "CodeType": "Normal",
+        "DisplayText": "symptoms",
+        "NumericValue": 2,
+        "StringValue": "symptoms",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-1b9f2a65",
+        "CodeType": "Normal",
+        "DisplayText": "spread/transmission",
+        "NumericValue": 3,
+        "StringValue": "spread_transmission",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-d51806b9",
+        "CodeType": "Normal",
+        "DisplayText": "how to prevent",
+        "NumericValue": 4,
+        "StringValue": "how_to_prevent",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-810e57bf",
+        "CodeType": "Normal",
+        "DisplayText": "how to treat",
+        "NumericValue": 5,
+        "StringValue": "how_to_treat",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-90686b2c",
+        "CodeType": "Normal",
+        "DisplayText": "government response",
+        "NumericValue": 6,
+        "StringValue": "government_response",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-02e10692",
+        "CodeType": "Normal",
+        "DisplayText": "somalia update",
+        "NumericValue": 7,
+        "StringValue": "somalia_update",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-3427630d",
+        "CodeType": "Normal",
+        "DisplayText": "rumour/stigma/misinfo",
+        "NumericValue": 8,
+        "StringValue": "rumour_stigma_misinfo",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-363c0b9f",
+        "CodeType": "Normal",
+        "DisplayText": "collective hope",
+        "NumericValue": 9,
+        "StringValue": "collective_hope",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-01de838c",
+        "CodeType": "Normal",
+        "DisplayText": "anxiety/panic",
+        "NumericValue": 10,
+        "StringValue": "anxiety_panic",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-a0a65db4",
+        "CodeType": "Normal",
+        "DisplayText": "religious hope/practice",
+        "NumericValue": 11,
+        "StringValue": "religious_hope_practice",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-6cf077c8",
+        "CodeType": "Normal",
+        "DisplayText": "denial",
+        "NumericValue": 12,
+        "StringValue": "denial",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-95d294a9",
+        "CodeType": "Normal",
+        "DisplayText": "urgent need",
+        "NumericValue": 13,
+        "StringValue": "urgent_need",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-a3bdbdcb",
+        "CodeType": "Normal",
+        "DisplayText": "(call for) awareness creation",
+        "NumericValue": 14,
+        "StringValue": "call_for_awareness_creation",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-33c09ab0",
+        "CodeType": "Normal",
+        "DisplayText": "(call for) right practice",
+        "NumericValue": 15,
+        "StringValue": "call_for_right_practice",
+        "VisibleInCoda": true
+      },
+      {
         "CodeID": "code-NA-f93d3eb7",
         "CodeType": "Control",
         "ControlCode": "NA",

--- a/code_schemes/s01e02.json
+++ b/code_schemes/s01e02.json
@@ -14,6 +14,146 @@
         "Shortcut": "e"
       },
       {
+        "CodeID": "code-Q-a5d3700d",
+        "CodeType": "Meta",
+        "MetaCode": "question",
+        "DisplayText": "meta: question",
+        "NumericValue": -100010,
+        "StringValue": "question",
+        "VisibleInCoda": true,
+        "Shortcut": "q"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "CodeID": "code-60e8993d",
+        "CodeType": "Normal",
+        "DisplayText": "about coronavirus",
+        "NumericValue": 1,
+        "StringValue": "about_coronavirus",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-00044bf7",
+        "CodeType": "Normal",
+        "DisplayText": "symptoms",
+        "NumericValue": 2,
+        "StringValue": "symptoms",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-1bef6c12",
+        "CodeType": "Normal",
+        "DisplayText": "spread/transmission",
+        "NumericValue": 3,
+        "StringValue": "spread_transmission",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-8c0b0ffc",
+        "CodeType": "Normal",
+        "DisplayText": "how to prevent",
+        "NumericValue": 4,
+        "StringValue": "how_to_prevent",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-503eb8c3",
+        "CodeType": "Normal",
+        "DisplayText": "how to treat",
+        "NumericValue": 5,
+        "StringValue": "how_to_treat",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-25dc275d",
+        "CodeType": "Normal",
+        "DisplayText": "government response",
+        "NumericValue": 6,
+        "StringValue": "government_response",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-7a52df11",
+        "CodeType": "Normal",
+        "DisplayText": "somalia update",
+        "NumericValue": 7,
+        "StringValue": "somalia_update",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-2f621a5c",
+        "CodeType": "Normal",
+        "DisplayText": "rumour/stigma/misinfo",
+        "NumericValue": 8,
+        "StringValue": "rumour_stigma_misinfo",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-226c9094",
+        "CodeType": "Normal",
+        "DisplayText": "collective hope",
+        "NumericValue": 9,
+        "StringValue": "collective_hope",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-43afc11c",
+        "CodeType": "Normal",
+        "DisplayText": "anxiety/panic",
+        "NumericValue": 10,
+        "StringValue": "anxiety_panic",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-cf88b525",
+        "CodeType": "Normal",
+        "DisplayText": "religious hope/practice",
+        "NumericValue": 11,
+        "StringValue": "religious_hope_practice",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-3dc2b860",
+        "CodeType": "Normal",
+        "DisplayText": "denial",
+        "NumericValue": 12,
+        "StringValue": "denial",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-5071795c",
+        "CodeType": "Normal",
+        "DisplayText": "urgent need",
+        "NumericValue": 13,
+        "StringValue": "urgent_need",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-77e25dc9",
+        "CodeType": "Normal",
+        "DisplayText": "(call for) awareness creation",
+        "NumericValue": 14,
+        "StringValue": "call_for_awareness_creation",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-ecf41c3f",
+        "CodeType": "Normal",
+        "DisplayText": "(call for) right practice",
+        "NumericValue": 15,
+        "StringValue": "call_for_right_practice",
+        "VisibleInCoda": true
+      },
+      {
         "CodeID": "code-NA-f93d3eb7",
         "CodeType": "Control",
         "ControlCode": "NA",

--- a/code_schemes/s01e03.json
+++ b/code_schemes/s01e03.json
@@ -14,6 +14,146 @@
         "Shortcut": "e"
       },
       {
+        "CodeID": "code-Q-a5d3700d",
+        "CodeType": "Meta",
+        "MetaCode": "question",
+        "DisplayText": "meta: question",
+        "NumericValue": -100010,
+        "StringValue": "question",
+        "VisibleInCoda": true,
+        "Shortcut": "q"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "CodeID": "code-a76c6422",
+        "CodeType": "Normal",
+        "DisplayText": "about coronavirus",
+        "NumericValue": 1,
+        "StringValue": "about_coronavirus",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-36d1d0f2",
+        "CodeType": "Normal",
+        "DisplayText": "symptoms",
+        "NumericValue": 2,
+        "StringValue": "symptoms",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-a6b5f693",
+        "CodeType": "Normal",
+        "DisplayText": "spread/transmission",
+        "NumericValue": 3,
+        "StringValue": "spread_transmission",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-7ea51109",
+        "CodeType": "Normal",
+        "DisplayText": "how to prevent",
+        "NumericValue": 4,
+        "StringValue": "how_to_prevent",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-5f5c3863",
+        "CodeType": "Normal",
+        "DisplayText": "how to treat",
+        "NumericValue": 5,
+        "StringValue": "how_to_treat",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-6c3ec494",
+        "CodeType": "Normal",
+        "DisplayText": "government response",
+        "NumericValue": 6,
+        "StringValue": "government_response",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-48ea64f9",
+        "CodeType": "Normal",
+        "DisplayText": "somalia update",
+        "NumericValue": 7,
+        "StringValue": "somalia_update",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-a380a79d",
+        "CodeType": "Normal",
+        "DisplayText": "rumour/stigma/misinfo",
+        "NumericValue": 8,
+        "StringValue": "rumour_stigma_misinfo",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-b60dbb20",
+        "CodeType": "Normal",
+        "DisplayText": "collective hope",
+        "NumericValue": 9,
+        "StringValue": "collective_hope",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-a3a1343c",
+        "CodeType": "Normal",
+        "DisplayText": "anxiety/panic",
+        "NumericValue": 10,
+        "StringValue": "anxiety_panic",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-bf907119",
+        "CodeType": "Normal",
+        "DisplayText": "religious hope/practice",
+        "NumericValue": 11,
+        "StringValue": "religious_hope_practice",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-4fff1378",
+        "CodeType": "Normal",
+        "DisplayText": "denial",
+        "NumericValue": 12,
+        "StringValue": "denial",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-03ee11b8",
+        "CodeType": "Normal",
+        "DisplayText": "urgent need",
+        "NumericValue": 13,
+        "StringValue": "urgent_need",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-461b7c0c",
+        "CodeType": "Normal",
+        "DisplayText": "(call for) awareness creation",
+        "NumericValue": 14,
+        "StringValue": "call_for_awareness_creation",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-ceadb52c",
+        "CodeType": "Normal",
+        "DisplayText": "(call for) right practice",
+        "NumericValue": 15,
+        "StringValue": "call_for_right_practice",
+        "VisibleInCoda": true
+      },
+      {
         "CodeID": "code-NA-f93d3eb7",
         "CodeType": "Control",
         "ControlCode": "NA",

--- a/code_schemes/s01e04.json
+++ b/code_schemes/s01e04.json
@@ -14,6 +14,146 @@
         "Shortcut": "e"
       },
       {
+        "CodeID": "code-Q-a5d3700d",
+        "CodeType": "Meta",
+        "MetaCode": "question",
+        "DisplayText": "meta: question",
+        "NumericValue": -100010,
+        "StringValue": "question",
+        "VisibleInCoda": true,
+        "Shortcut": "q"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "CodeID": "code-d4804c6c",
+        "CodeType": "Normal",
+        "DisplayText": "about coronavirus",
+        "NumericValue": 1,
+        "StringValue": "about_coronavirus",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-4e6c98da",
+        "CodeType": "Normal",
+        "DisplayText": "symptoms",
+        "NumericValue": 2,
+        "StringValue": "symptoms",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-5af71d93",
+        "CodeType": "Normal",
+        "DisplayText": "spread/transmission",
+        "NumericValue": 3,
+        "StringValue": "spread_transmission",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-c3433d75",
+        "CodeType": "Normal",
+        "DisplayText": "how to prevent",
+        "NumericValue": 4,
+        "StringValue": "how_to_prevent",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-ef1c4eec",
+        "CodeType": "Normal",
+        "DisplayText": "how to treat",
+        "NumericValue": 5,
+        "StringValue": "how_to_treat",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-2913fa5e",
+        "CodeType": "Normal",
+        "DisplayText": "government response",
+        "NumericValue": 6,
+        "StringValue": "government_response",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-7e03af2e",
+        "CodeType": "Normal",
+        "DisplayText": "somalia update",
+        "NumericValue": 7,
+        "StringValue": "somalia_update",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-ca9e8dda",
+        "CodeType": "Normal",
+        "DisplayText": "rumour/stigma/misinfo",
+        "NumericValue": 8,
+        "StringValue": "rumour_stigma_misinfo",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-a8fb09af",
+        "CodeType": "Normal",
+        "DisplayText": "collective hope",
+        "NumericValue": 9,
+        "StringValue": "collective_hope",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-ba37d814",
+        "CodeType": "Normal",
+        "DisplayText": "anxiety/panic",
+        "NumericValue": 10,
+        "StringValue": "anxiety_panic",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-5046f00f",
+        "CodeType": "Normal",
+        "DisplayText": "religious hope/practice",
+        "NumericValue": 11,
+        "StringValue": "religious_hope_practice",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-8fab19a1",
+        "CodeType": "Normal",
+        "DisplayText": "denial",
+        "NumericValue": 12,
+        "StringValue": "denial",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-3ede1847",
+        "CodeType": "Normal",
+        "DisplayText": "urgent need",
+        "NumericValue": 13,
+        "StringValue": "urgent_need",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-fb776c0a",
+        "CodeType": "Normal",
+        "DisplayText": "(call for) awareness creation",
+        "NumericValue": 14,
+        "StringValue": "call_for_awareness_creation",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-ae2cb742",
+        "CodeType": "Normal",
+        "DisplayText": "call for right practice",
+        "NumericValue": 15,
+        "StringValue": "call_for_right_practice",
+        "VisibleInCoda": true
+      },
+      {
         "CodeID": "code-NA-f93d3eb7",
         "CodeType": "Control",
         "ControlCode": "NA",

--- a/code_schemes/s01e04.json
+++ b/code_schemes/s01e04.json
@@ -148,7 +148,7 @@
       {
         "CodeID": "code-ae2cb742",
         "CodeType": "Normal",
-        "DisplayText": "call for right practice",
+        "DisplayText": "(call for) right practice",
         "NumericValue": 15,
         "StringValue": "call_for_right_practice",
         "VisibleInCoda": true


### PR DESCRIPTION
This adds question & statement meta codes erroneously omitted in previous pr and standard `CESC - KK COVI19` L3 normal themes: https://docs.google.com/spreadsheets/d/1Sgf1rXkHgghH1ViLswE8QkikePeRm9S6eNGDzQs05xc/edit?usp=sharing