### PR TITLE
add kenyan telephone operators

### DIFF
--- a/code_schemes/somalia_operator.json
+++ b/code_schemes/somalia_operator.json
@@ -70,6 +70,17 @@
       ]
     },
     {
+      "CodeID": "code-64b64595",
+      "CodeType": "Normal",
+      "DisplayText": "kenyan telephone",
+      "NumericValue": 6,
+      "StringValue": "kenyan telephone",
+      "VisibleInCoda": true,
+      "MatchValues":  [
+        "kenyan telephone"
+      ]
+    },
+    {
       "CodeID": "code-NA-f93d3eb7",
       "CodeType": "Control",
       "ControlCode": "NA",

--- a/code_schemes/somalia_operator.json
+++ b/code_schemes/somalia_operator.json
@@ -74,7 +74,7 @@
       "CodeType": "Normal",
       "DisplayText": "kenyan telephone",
       "NumericValue": 7,
-      "StringValue": "kenyan telephone",
+      "StringValue": "kenyan_telephone",
       "VisibleInCoda": true,
       "MatchValues":  [
         "kenyan telephone"

--- a/code_schemes/somalia_operator.json
+++ b/code_schemes/somalia_operator.json
@@ -73,7 +73,7 @@
       "CodeID": "code-64b64595",
       "CodeType": "Normal",
       "DisplayText": "kenyan telephone",
-      "NumericValue": 6,
+      "NumericValue": 7,
       "StringValue": "kenyan telephone",
       "VisibleInCoda": true,
       "MatchValues":  [


### PR DESCRIPTION
Some of the phone numbers in unicef instance are kenyan numbers therefore the pipeline crashes during fetch raw data. we should probably rename this to telephone_operators everywhere. 