### PR TITLE
filter katikati sms survey messages

### DIFF
--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -68,8 +68,7 @@ def get_rqa_coding_plans(pipeline_name):
                    run_id_field="rqa_s01e03_run_id",
                    coda_filename="UNICEF_COVID19_SOM_s01e03.json",
                    icr_filename="rqa_s01e03.csv",
-                   katikati_survey_start_time="2020-07-24T14:00:00+03:00",
-                   katikati_survey_end_time="2020-07-26T00:00:00+03:00",
+                   katikati_survey_time_ranges=[("2020-07-24T14:00:00+03:00","2020-07-26T00:00:00+03:00")],
                    coding_configurations=[
                        CodingConfiguration(
                            coding_mode=CodingModes.MULTIPLE,

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -68,6 +68,8 @@ def get_rqa_coding_plans(pipeline_name):
                    run_id_field="rqa_s01e03_run_id",
                    coda_filename="UNICEF_COVID19_SOM_s01e03.json",
                    icr_filename="rqa_s01e03.csv",
+                   katikati_survey_start_time="2020-07-24T14:00:00+03:00",
+                   katikati_survey_end_time="2020-07-26T00:00:00+03:00",
                    coding_configurations=[
                        CodingConfiguration(
                            coding_mode=CodingModes.MULTIPLE,

--- a/src/auto_code.py
+++ b/src/auto_code.py
@@ -69,6 +69,8 @@ class AutoCode(object):
         time_keys = {plan.time_field for plan in PipelineConfiguration.RQA_CODING_PLANS}
         data = MessageFilters.filter_time_range(data, time_keys, project_start_date, project_end_date)
 
+        data = MessageFilters.filter_katikati_sms_survey_messages(data, time_keys)
+
         return data
 
     @classmethod

--- a/src/lib/configuration_objects.py
+++ b/src/lib/configuration_objects.py
@@ -18,7 +18,8 @@ class CodingConfiguration(object):
 # TODO: Rename CodingPlan to something like DatasetConfiguration?
 class CodingPlan(object):
     def __init__(self, raw_field, coding_configurations, raw_field_fold_strategy, coda_filename=None, ws_code=None,
-                 time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None):
+                 time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None,
+                 katikati_survey_start_time=None, katikati_survey_end_time=None):
         self.raw_field = raw_field
         self.time_field = time_field
         self.run_id_field = run_id_field
@@ -29,6 +30,9 @@ class CodingPlan(object):
         self.ws_code = ws_code
         self.raw_field_fold_strategy = raw_field_fold_strategy
         self.dataset_name = raw_field
+        self.katikati_survey_start_time = katikati_survey_start_time
+        self.katikati_survey_end_time = katikati_survey_end_time
+
 
         if id_field is None:
             id_field = "{}_id".format(self.raw_field)

--- a/src/lib/configuration_objects.py
+++ b/src/lib/configuration_objects.py
@@ -19,7 +19,7 @@ class CodingConfiguration(object):
 class CodingPlan(object):
     def __init__(self, raw_field, coding_configurations, raw_field_fold_strategy, coda_filename=None, ws_code=None,
                  time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None,
-                 katikati_survey_start_time=None, katikati_survey_end_time=None):
+                 katikati_survey_time_ranges=None,):
         self.raw_field = raw_field
         self.time_field = time_field
         self.run_id_field = run_id_field
@@ -30,8 +30,7 @@ class CodingPlan(object):
         self.ws_code = ws_code
         self.raw_field_fold_strategy = raw_field_fold_strategy
         self.dataset_name = raw_field
-        self.katikati_survey_start_time = katikati_survey_start_time
-        self.katikati_survey_end_time = katikati_survey_end_time
+        self.katikati_survey_time_ranges = katikati_survey_time_ranges
 
 
         if id_field is None:

--- a/src/lib/message_filters.py
+++ b/src/lib/message_filters.py
@@ -141,30 +141,42 @@ class MessageFilters(object):
         :rtype: list of TracedData
         """
         # De-duplicate time_keys
-        assert isinstance(time_keys, set)
+        time_keys = set(time_keys)
 
         log.debug(f"Filtering out messages received during katikati sms survey broadcast period"
                   f"for time keys {time_keys}...")
 
+        # Validate the input data to ensure that each message object only contains one of the time_keys.
+        for td in messages:
+            matching_time_keys = 0
+            for time_key in time_keys:
+                if time_key in td:
+                    matching_time_keys += 1
+            assert matching_time_keys == 1, matching_time_keys
+
         # Not all episodes have Katikati Sms Survey check those that have and filter the messages
-        katikati_survey_messages = set()
+        katikati_survey_messages = []
         for episode_plan in PipelineConfiguration.RQA_CODING_PLANS:
-            if episode_plan.katikati_survey_start_time is None:
+            if episode_plan.katikati_survey_time_ranges is None:
                 continue
 
             episode_katikati_survey_messages = 0
             for td in messages:
                 if episode_plan.raw_field in td:
                     for time_key in time_keys:
-                        if time_key in td and isoparse(episode_plan.katikati_survey_start_time) <= isoparse(td[time_key]) \
-                                < isoparse(episode_plan.katikati_survey_end_time):
-                            katikati_survey_messages.add(td)
-                            episode_katikati_survey_messages += 1
+                        for time_range in episode_plan.katikati_survey_time_ranges:
+                            if time_key in td and isoparse(time_range[0]) <= isoparse(td[time_key]) \
+                                    < isoparse(time_range[1]):
+                                katikati_survey_messages.append(td)
+                                episode_katikati_survey_messages += 1
 
             log.debug(f"Found {episode_katikati_survey_messages} messages received during katikati sms survey broadcast period"
-                      f"{episode_plan.katikati_survey_start_time} in {episode_plan.raw_field}")
+                      f"{episode_plan.katikati_survey_time_ranges} in {episode_plan.raw_field}")
 
         filtered = [td for td in messages if td not in katikati_survey_messages]
+
+        assert len(filtered) + len(katikati_survey_messages) == len(messages)
+
         log.info(f"Filtered out {len(katikati_survey_messages)} messages recieved during katikati sms survey broadcast period"
                  f"Returning {len(filtered)}/{len(messages)} messages.")
 

--- a/src/lib/message_filters.py
+++ b/src/lib/message_filters.py
@@ -165,7 +165,7 @@ class MessageFilters(object):
                       f"{episode_plan.katikati_survey_start_time} in {episode_plan.raw_field}")
 
         filtered = [td for td in messages if td not in katikati_survey_messages]
-        log.info(f"Filtered out {len(katikati_survey_messages)} messages recieved during katikati sms survey broadcast period"
+        log.info(f"Filtered out {len(katikati_survey_messages)} messages recieved during katikati sms survey broadcast period. "
                  f"Returning {len(filtered)}/{len(messages)} messages.")
 
         return filtered

--- a/src/lib/message_filters.py
+++ b/src/lib/message_filters.py
@@ -161,7 +161,7 @@ class MessageFilters(object):
                             katikati_survey_messages.append(td)
                             episode_katikati_survey_messages += 1
 
-            log.debug(f"Found {episode_katikati_survey_messages} messages received during katikati sms survey broadcast period"
+            log.debug(f"Found {episode_katikati_survey_messages} messages received during katikati sms survey broadcast period. "
                       f"{episode_plan.katikati_survey_start_time} in {episode_plan.raw_field}")
 
         filtered = [td for td in messages if td not in katikati_survey_messages]

--- a/src/lib/message_filters.py
+++ b/src/lib/message_filters.py
@@ -147,7 +147,7 @@ class MessageFilters(object):
                   f"for time keys {time_keys}...")
 
         # Not all episodes have Katikati Sms Survey check those that have and filter the messages
-        katikati_survey_messages = []
+        katikati_survey_messages = set()
         for episode_plan in PipelineConfiguration.RQA_CODING_PLANS:
             if episode_plan.katikati_survey_start_time is None:
                 continue
@@ -158,7 +158,7 @@ class MessageFilters(object):
                     for time_key in time_keys:
                         if time_key in td and isoparse(episode_plan.katikati_survey_start_time) <= isoparse(td[time_key]) \
                                 < isoparse(episode_plan.katikati_survey_end_time):
-                            katikati_survey_messages.append(td)
+                            katikati_survey_messages.add(td)
                             episode_katikati_survey_messages += 1
 
             log.debug(f"Found {episode_katikati_survey_messages} messages received during katikati sms survey broadcast period"


### PR DESCRIPTION
We sent out SMS survey on Friday -> Saturday that was captured in both kk datasets and p1 pipeline datasets. This helps us filter out any messages sent during the survey period. If this looks okay I will adopt it for Imaqal during next week's survey. 
To fully land this I will pause pipeline auto-execution -> delete uncoded messages from coda -> pull coded messages -> reset sequence numbers for the coded messages -> push coded messages back to coda -> Rerun full pipeline. 